### PR TITLE
feat: add neotest plugin and config for Golang tests

### DIFF
--- a/containerfiles/install-scripts/install-gvm.sh
+++ b/containerfiles/install-scripts/install-gvm.sh
@@ -5,9 +5,12 @@ gvm_ver="${1:?missing gvm version}"
 
 arch="$(uname -m)"
 case "$arch" in
-  x86_64) garch="amd64" ;;
-  aarch64) garch="arm64" ;;
-  *) echo "unsupported arch: $arch" >&2; exit 1 ;;
+x86_64) garch="amd64" ;;
+aarch64) garch="arm64" ;;
+*)
+  echo "unsupported arch: $arch" >&2
+  exit 1
+  ;;
 esac
 
 url="https://github.com/andrewkroh/gvm/releases/download/v${gvm_ver}/gvm-linux-${garch}"
@@ -16,3 +19,5 @@ chmod +x /usr/local/bin/gvm
 
 # sanity check (does not require network)
 gvm -h >/dev/null
+
+dnf install -y delve

--- a/dotfiles/.bashrc.d/30_nvm.bashrc
+++ b/dotfiles/.bashrc.d/30_nvm.bashrc
@@ -1,5 +1,12 @@
 export NVM_DIR="$HOME/.config/nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
+# Install node and enable via nvm
+if ! command -v node >/dev/null 2>&1; then
+  nvm install node
+  nvm use node
+fi
+
 export PATH="$HOME/.npm-global/bin:$PATH"
 export PATH="$HOME/.local/bin:$PATH"

--- a/dotfiles/.bashrc.d/9999_additional.bashrc
+++ b/dotfiles/.bashrc.d/9999_additional.bashrc
@@ -1,0 +1,3 @@
+mkdir -p "$HOME/.cache/opentofu/plugins"
+export TF_PLUGIN_CACHE_DIR="$HOME/.cache/opentofu/plugins"
+export XDG_CACHE_HOME="$HOME/.cache"

--- a/dotfiles/.config/git/config
+++ b/dotfiles/.config/git/config
@@ -26,4 +26,7 @@
 
 # optional: avoid "unsafe repository" when bind-mounting into containers
 [safe]
-        directory = /repo
+  directory = /repo
+
+[url "ssh://git@github.com/"]
+    insteadOf = https://github.com/

--- a/dotfiles/.config/nvim/lua/plugins/neotest.lua
+++ b/dotfiles/.config/nvim/lua/plugins/neotest.lua
@@ -1,0 +1,34 @@
+return {
+  {
+    "nvim-neotest/neotest",
+    dependencies = {
+      "nvim-neotest/nvim-nio",
+      "nvim-lua/plenary.nvim",
+      "antoinemadec/FixCursorHold.nvim",
+      {
+        "nvim-treesitter/nvim-treesitter",
+        branch = "main",
+        build = function()
+          vim.cmd(":TSUpdate go")
+        end,
+      },
+      {
+        "fredrikaverpil/neotest-golang",
+        version = "*", -- Optional, but recommended; track releases
+        build = function()
+          vim.system({ "go", "install", "gotest.tools/gotestsum@latest" }):wait() -- Optional, but recommended
+        end,
+      },
+    },
+    config = function()
+      local config = {
+        runner = "gotestsum", -- Optional, but recommended
+      }
+      require("neotest").setup({
+        adapters = {
+          require("neotest-golang")(config),
+        },
+      })
+    end,
+  },
+}


### PR DESCRIPTION
- Added neotest and neotest-golang plugins to Neovim config for running Go tests with gotestsum.
- Updated install-gvm.sh to install delve for Go debugging.
- Improved nvm bashrc to auto-install and use Node.js if missing.
- Added bashrc for OpenTofu plugin cache and XDG cache home.
- Updated git config to use SSH for GitHub and fixed safe directory indentation.